### PR TITLE
adding hardware watchdog

### DIFF
--- a/firmware/lib/core/include/core.h
+++ b/firmware/lib/core/include/core.h
@@ -64,6 +64,8 @@ class Core {
   // make this public to allow debug to be set.
         Scheduler _scheduler;
 
+        void ResetHardwareWatchdog();
+
     private:
         uint32_t _elapsed;
         Timer _primaryTimer;
@@ -71,6 +73,7 @@ class Core {
         CoreState _state;
         void Tick();
         void CreateWatchdog(uint32_t timeoutMs);
+        void CreateHardwareWatchdog();
         bool ResetWatchdog();
         uint32_t GetElapsedTime();
 

--- a/firmware/lib/hal/TF800A12K.cpp
+++ b/firmware/lib/hal/TF800A12K.cpp
@@ -54,66 +54,88 @@ int SL_PS::init() {
   if (!strlen(manuf)) strcpy(manuf, "UNKWN");
   Serial.println(manuf);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_Model(ADDRESS);
   Serial.print("Model: ");
   if (!strlen(model)) strcpy(manuf, "UNKWN");
   Serial.println(model);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_VoltageString(ADDRESS);
   Serial.print("VoltageSt: ");
   if (!strlen(voltage_string)) strcpy(manuf, "UNKWN");
   Serial.println(voltage_string);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_Revision(ADDRESS);
   Serial.print("Rev: ");
   if (!strlen(revision)) strcpy(manuf, "UNKWN");
   Serial.println(revision);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_ManufDate(ADDRESS);
   Serial.print("ManufDate: ");
   if (!strlen(manuf_date)) strcpy(manuf, "UNKWN");
   Serial.println(manuf_date);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_Serial(ADDRESS);
   Serial.print("Serial: ");
   if (!strlen(serial)) strcpy(manuf, "UNKWN");
   Serial.println(serial);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_Country(ADDRESS);
   Serial.print("Country: ");
   if (!strlen(country)) strcpy(manuf, "UNKWN");
   Serial.println(country);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_RateVoltage(ADDRESS);
   Serial.print("RateVoltage: ");
   if (rate_voltage < 0) Serial.println("UNKWN");
   else Serial.println(rate_voltage);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_RateCurrent(ADDRESS);
   Serial.print("RateCurrent: ");
   if (rate_current < 0) Serial.println("UNKWN");
   else Serial.println(rate_current);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_MaxVoltage(ADDRESS);
   Serial.print("MaxVoltage: ");
   if (max_voltage < 0) Serial.println("UNKWN");
   else Serial.println(max_voltage);
   delay(MYDELAY);
+   watchdogReset();
+
 
   getPS_MaxCurrent(ADDRESS);
   Serial.print("MaxCurrent: ");
   if (max_current < 0) Serial.println("UNKWN");
   else Serial.println(max_current);
   delay(MYDELAY);
+   watchdogReset();
+
 
 //  snprintf(packetBuffer, sizeof packetBuffer, "{ \"Manufacturer\": \"%s\", \"Model\": \"%s\", \"VoltString\": \"%s\", \"Revision\": \"%s\", \"Serial\": \"%s\", \"VoltageRating\": %d, \"CurrentRating\": %d, \"MaxVoltage\": %d, \"MaxCurrent\": %d}", manuf, model, voltage_string, revision, serial, rate_voltage, rate_current, max_voltage, max_current);
 //  sendMsg(packetBuffer);

--- a/firmware/lib/task/cog_task.cpp
+++ b/firmware/lib/task/cog_task.cpp
@@ -21,6 +21,7 @@
 // from: https://learn.adafruit.com/memories-of-an-arduino/measuring-free-memory
 // This should be made into a separte task,
 // this is just for debugging...
+// TODO: Move this into the core, and invoke it within a DEBUG_LEVEL guard.
 #ifdef __arm__
 // should use uinstd.h to define sbrk but Due causes a conflict
 extern "C" char* sbrk(int incr);

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -67,7 +67,7 @@ build_flags =
 	-D USE_MAX31850_THERMOCOUPLES=1
 ;; This turns off the emergency shutdown when we loose a
 ;; thermocouple. It allows testing.
-        -D ALLOW_BAD_THERMOCOUPLES_FOR_TESTING
+;;        -D ALLOW_BAD_THERMOCOUPLES_FOR_TESTING
 
 [env:due_stage2_heater]
 platform = atmelsam

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -72,8 +72,8 @@ SerialReportTask serialReportTask;
 MachineConfig machineConfig;
 /***********************************/
 
-// #define ETHERNET_BOARD_PRESENT 1
-#define ETHERNET_BOARD_PRESENT 0 //No ethernet.
+#define ETHERNET_BOARD_PRESENT 1
+// #define ETHERNET_BOARD_PRESENT 0 //No ethernet.
 
 
 // This is to allow a code idiom compatible with the way
@@ -84,6 +84,8 @@ MachineConfig *getConfig() {
 
 // TODO: we need to have setups for individual pieces
 // of the Hardware Abstraction Layer
+// I don't know why this didn't work inside the core.cpp file!!!
+
 
 void setup()
 {
@@ -93,6 +95,11 @@ void setup()
    // WARNING! need 5 second delay for pio compiler it seems
   // DO NOT REMOVE THIS STATEMENT!
   delay(5000);
+
+
+  // We're doing this here because the Core may not be initialized
+  watchdogReset();
+
 
   // TODO: consider doing this....
     // Serial.begin(BAUDRATE);
@@ -140,6 +147,8 @@ void setup()
   }
   Debug<const char *>("Core booted...\n");
   delay(100);
+
+  core.ResetHardwareWatchdog();
 
   machineConfig.init();
   //  Eventually we will migrate all hardware to the COG_HAL..
@@ -284,6 +293,9 @@ void setup()
     abort();
   }
 
+  core.ResetHardwareWatchdog();
+
+
   heaterPIDTask.whichHeater = (Stage2Heater) 0;
 
   heaterPIDTask.dutyCycleTask = &dutyCycleTask;
@@ -299,7 +311,7 @@ void setup()
   OEDCSNetworkTask.DEBUG_UDP = 0;
   OEDCSNetworkTask.net_udp.DEBUG_UDP = 0;
 //  readTempsTask.DEBUG_READ_TEMPS = 0;  //FLE 20230918
-  readTempsTask.DEBUG_READ_TEMPS = 1;
+  readTempsTask.DEBUG_READ_TEMPS = 0;
   oedcsSerialInputTask.DEBUG_SERIAL = 0;
   getConfig()->script->DEBUG_MS = 0;
   OxCore::Debug<const char *>("Added tasks\n");


### PR DESCRIPTION
This puts hardware watchdog capabilities into the core.

We should use "safeDelay", but we haven't gotten it form @gmulligan yet.